### PR TITLE
Validate Manifests and Catalog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
+FROM golang:1.10 as tester
+WORKDIR /go/src/github.com/operator-framework/operator-manifests
+COPY . .
+RUN go test ./cmd/catalogbuilder
+RUN go get github.com/operator-framework/operator-lifecycle-manager/cmd/validator
+RUN wget -P ./deploy/chart/templates https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/chart/templates/05-catalogsource.crd.yaml
+RUN wget -P ./deploy/chart/templates https://raw.githubusercontent.com/operator-framework/operator-lifecycle-manager/master/deploy/chart/templates/03-clusterserviceversion.crd.yaml
+RUN validator ./manifests
+
 FROM golang:1.10 as builder
-LABEL builder=true
 WORKDIR /go/src/github.com/operator-framework/operator-manifests
 COPY cmd cmd
 RUN go build -o bin/catalogbuilder ./cmd/catalogbuilder
 RUN chmod +x bin/catalogbuilder
 
 FROM scratch
-LABEL main=true
 WORKDIR /
 COPY --from=builder /go/src/github.com/operator-framework/operator-manifests/bin/catalogbuilder /catalogbuilder
 COPY manifests /manifests

--- a/manifests/etcd-operator/etcd.package.yaml
+++ b/manifests/etcd-operator/etcd.package.yaml
@@ -1,4 +1,4 @@
-#! package-manifest: ../../catalog_resources/etcdoperator.v0.9.2.clusterserviceversion.yaml
+#! package-manifest: ./manifests/etcd-operator/etcdoperator.v0.9.2.clusterserviceversion.yaml
 packageName: etcd
 channels:
 - name: alpha

--- a/manifests/etcd-operator/etcdoperator.clusterserviceversion.yaml
+++ b/manifests/etcd-operator/etcdoperator.clusterserviceversion.yaml
@@ -1,4 +1,4 @@
-#! validate-crd: ../../deploy/chart/templates/03-clusterserviceversion.crd.yaml
+#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: app.coreos.com/v1alpha1
 kind: ClusterServiceVersion-v1

--- a/manifests/etcd-operator/etcdoperator.v0.9.0.clusterserviceversion.yaml
+++ b/manifests/etcd-operator/etcdoperator.v0.9.0.clusterserviceversion.yaml
@@ -1,4 +1,4 @@
-#! validate-crd: ../../deploy/chart/templates/03-clusterserviceversion.crd.yaml
+#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: app.coreos.com/v1alpha1
 kind: ClusterServiceVersion-v1

--- a/manifests/etcd-operator/etcdoperator.v0.9.2.clusterserviceversion.yaml
+++ b/manifests/etcd-operator/etcdoperator.v0.9.2.clusterserviceversion.yaml
@@ -1,4 +1,4 @@
-#! validate-crd: ../../deploy/chart/templates/03-clusterserviceversion.crd.yaml
+#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: app.coreos.com/v1alpha1
 kind: ClusterServiceVersion-v1

--- a/manifests/prometheus-operator/prometheus.package.yaml
+++ b/manifests/prometheus-operator/prometheus.package.yaml
@@ -1,4 +1,4 @@
-#! package-manifest: ../../catalog_resources/prometheusoperator.0.15.0.clusterserviceversion.yaml
+#! package-manifest: ./manifests/prometheus-operator/prometheusoperator.0.15.0.clusterserviceversion.yaml
 packageName: prometheus
 channels:
 - name: alpha

--- a/manifests/prometheus-operator/prometheusoperator.0.14.0.clusterserviceversion.yaml
+++ b/manifests/prometheus-operator/prometheusoperator.0.14.0.clusterserviceversion.yaml
@@ -1,4 +1,4 @@
-#! validate-crd: ../../deploy/chart/templates/03-clusterserviceversion.crd.yaml
+#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: app.coreos.com/v1alpha1
 kind: ClusterServiceVersion-v1

--- a/manifests/prometheus-operator/prometheusoperator.0.15.0.clusterserviceversion.yaml
+++ b/manifests/prometheus-operator/prometheusoperator.0.15.0.clusterserviceversion.yaml
@@ -1,4 +1,4 @@
-#! validate-crd: ../../deploy/chart/templates/03-clusterserviceversion.crd.yaml
+#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: app.coreos.com/v1alpha1
 kind: ClusterServiceVersion-v1

--- a/manifests/vault-operator/vault.package.yaml
+++ b/manifests/vault-operator/vault.package.yaml
@@ -1,4 +1,4 @@
-#! package-manifest: ../../catalog_resources/vaultoperator.0.1.9.clusterserviceversion.yaml
+#! package-manifest: ./manifests/vault-operator/vaultoperator.0.1.9.clusterserviceversion.yaml
 packageName: vault
 channels:
 - name: alpha

--- a/manifests/vault-operator/vaultoperator.0.1.9.clusterserviceversion.yaml
+++ b/manifests/vault-operator/vaultoperator.0.1.9.clusterserviceversion.yaml
@@ -1,4 +1,4 @@
-#! validate-crd: ../../deploy/chart/templates/03-clusterserviceversion.crd.yaml
+#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: app.coreos.com/v1alpha1
 kind: ClusterServiceVersion-v1

--- a/manifests/vault-operator/vaultoperator.clusterserviceversion.yaml
+++ b/manifests/vault-operator/vaultoperator.clusterserviceversion.yaml
@@ -1,4 +1,4 @@
-#! validate-crd: ../../deploy/chart/templates/03-clusterserviceversion.crd.yaml
+#! validate-crd: ./deploy/chart/templates/03-clusterserviceversion.crd.yaml
 #! parse-kind: ClusterServiceVersion
 apiVersion: app.coreos.com/v1alpha1
 kind: ClusterServiceVersion-v1

--- a/operator-manifests.catalogsource.yaml
+++ b/operator-manifests.catalogsource.yaml
@@ -1,4 +1,4 @@
-#! validate-crd: ../../deploy/chart/templates/05-catalogsource.crd.yaml
+#! validate-crd: ./deploy/chart/templates/05-catalogsource.crd.yaml
 #! parse-kind: CatalogSource
 apiVersion: app.coreos.com/v1alpha1
 kind: CatalogSource-v1


### PR DESCRIPTION
### Description

Adds schema validation for manifest resources using `validator` binary built from https://github.com/operator-framework/operator-lifecycle-manager/cmd/validator.

### Testing

1. Run `docker build -t quay.io/operatorframework/operator-manifests:ALM-593 .`
2. Build passes

Addresses https://jira.coreos.com/browse/ALM-593