### PR TITLE
Update version number in CRDs to a tri-dotted format e.g. x.y.z

### DIFF
--- a/community-operators/amq-streams/v1.0.0.beta/amq-streams-kafka.crd.yaml
+++ b/community-operators/amq-streams/v1.0.0.beta/amq-streams-kafka.crd.yaml
@@ -6,7 +6,7 @@ metadata:
     app: strimzi
 spec:
   group: kafka.strimzi.io
-  version: v1alpha1
+  version: 1.0.0
   scope: Namespaced
   names:
     kind: Kafka

--- a/community-operators/amq-streams/v1.0.0.beta/amq-streams-kafkaconnect.crd.yaml
+++ b/community-operators/amq-streams/v1.0.0.beta/amq-streams-kafkaconnect.crd.yaml
@@ -6,7 +6,7 @@ metadata:
     app: strimzi
 spec:
   group: kafka.strimzi.io
-  version: v1alpha1
+  version: 1.0.0
   scope: Namespaced
   names:
     kind: KafkaConnect

--- a/community-operators/amq-streams/v1.0.0.beta/amq-streams-kafkaconnects2i.crd.yaml
+++ b/community-operators/amq-streams/v1.0.0.beta/amq-streams-kafkaconnects2i.crd.yaml
@@ -6,7 +6,7 @@ metadata:
     app: strimzi
 spec:
   group: kafka.strimzi.io
-  version: v1alpha1
+  version: 1.0.0
   scope: Namespaced
   names:
     kind: KafkaConnectS2I

--- a/community-operators/amq-streams/v1.0.0.beta/amq-streams-kafkatopic.crd.yaml
+++ b/community-operators/amq-streams/v1.0.0.beta/amq-streams-kafkatopic.crd.yaml
@@ -6,7 +6,7 @@ metadata:
     app: strimzi
 spec:
   group: kafka.strimzi.io
-  version: v1alpha1
+  version: 1.0.0
   scope: Namespaced
   names:
     kind: KafkaTopic

--- a/community-operators/amq-streams/v1.0.0.beta/amq-streams-kafkauser.crd.yaml
+++ b/community-operators/amq-streams/v1.0.0.beta/amq-streams-kafkauser.crd.yaml
@@ -6,7 +6,7 @@ metadata:
     app: strimzi
 spec:
   group: kafka.strimzi.io
-  version: v1alpha1
+  version: 1.0.0
   scope: Namespaced
   names:
     kind: KafkaUser


### PR DESCRIPTION
A dotted -tri format version number is expected which is causing build to fail

```
time="2019-06-05T19:16:09Z" level=info msg="could not decode contents of file manifests/amq-streams/amq-streams-kafka.crd.yaml into package: error unmarshaling JSON: v1alpha1 is not in dotted-tri format" dir=manifests file=amq-streams-kafka.crd.yaml load=bundles
```