### PR TITLE
Fix broken links - OLM Documentation was replaced by doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 bin
+.idea

--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ Run the following to create a new catalog source in your cluster containing all 
 2. Run `docker run -it quay.io/operatorframework/operator-manifests > ./out`
 3. Run `kubectl create -f ./out`
 
-You can now create install plans and subscriptions for the Operator packages, and OLM will take care of creating CRDs and updates. See the [OLM catalog Operator docs](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/architecture.md#catalog-operator) for more information.
+You can now create install plans and subscriptions for the Operator packages, and OLM will take care of creating CRDs and updates. See the [OLM catalog Operator docs](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/architecture.md#catalog-operator) for more information.


### PR DESCRIPTION
**Description of the change:**
The Dir of docs in OLM was changed from Documentation to doc. This change is to fix the broken links. 

**Motivation for the change:**

- https://github.com/operator-framework/operator-sdk/issues/1887
